### PR TITLE
Cleanups and Code Structure Improvements

### DIFF
--- a/java/org/networkcalculus/dnc/AlgDncBackend_MPARTC_DISCO_Affine.java
+++ b/java/org/networkcalculus/dnc/AlgDncBackend_MPARTC_DISCO_Affine.java
@@ -34,8 +34,10 @@ import org.networkcalculus.dnc.bounds.BoundingCurves;
 import org.networkcalculus.dnc.bounds.Bounds;
 import org.networkcalculus.dnc.bounds.disco.BoundingCurves_Disco_ConPwAffine;
 import org.networkcalculus.dnc.bounds.disco.Bounds_Disco_PwAffine;
+import org.networkcalculus.dnc.curves.CurveUtils;
 import org.networkcalculus.dnc.curves.Curve_PwAffine;
 import org.networkcalculus.dnc.curves.LinearSegment;
+import org.networkcalculus.dnc.curves.disco.pw_affine.CurveUtils_Disco_PwAffine;
 import org.networkcalculus.dnc.curves.mpa_rtc.LinearSegment_MPARTC;
 import org.networkcalculus.dnc.curves.mpa_rtc.pw_affine.Curve_MPARTC_PwAffine;
 
@@ -60,6 +62,11 @@ public enum AlgDncBackend_MPARTC_DISCO_Affine implements AlgDncBackend {
 	@Override
 	public Curve_PwAffine getCurveFactory() {
 		return Curve_MPARTC_PwAffine.getFactory();
+	}
+
+	@Override
+	public CurveUtils getCurveUtils() {
+		return CurveUtils_Disco_PwAffine.getInstance();
 	}
 
 	@Override 

--- a/java/org/networkcalculus/dnc/AlgDncBackend_MPARTC_DISCO_Affine.java
+++ b/java/org/networkcalculus/dnc/AlgDncBackend_MPARTC_DISCO_Affine.java
@@ -34,8 +34,8 @@ import org.networkcalculus.dnc.bounds.BoundingCurves;
 import org.networkcalculus.dnc.bounds.Bounds;
 import org.networkcalculus.dnc.bounds.disco.BoundingCurves_Disco_ConPwAffine;
 import org.networkcalculus.dnc.bounds.disco.Bounds_Disco_PwAffine;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.curves.CurveUtils;
-import org.networkcalculus.dnc.curves.Curve_PwAffine;
 import org.networkcalculus.dnc.curves.LinearSegment;
 import org.networkcalculus.dnc.curves.disco.pw_affine.CurveUtils_Disco_PwAffine;
 import org.networkcalculus.dnc.curves.mpa_rtc.LinearSegment_MPARTC;
@@ -60,7 +60,7 @@ public enum AlgDncBackend_MPARTC_DISCO_Affine implements AlgDncBackend {
 	}
 
 	@Override
-	public Curve_PwAffine getCurveFactory() {
+	public CurveFactory_Affine getCurveFactory() {
 		return Curve_MPARTC_PwAffine.getFactory();
 	}
 

--- a/java/org/networkcalculus/dnc/AlgDncBackend_MPARTC_DISCO_ConPwAffine.java
+++ b/java/org/networkcalculus/dnc/AlgDncBackend_MPARTC_DISCO_ConPwAffine.java
@@ -35,7 +35,7 @@ import org.networkcalculus.dnc.bounds.Bounds;
 import org.networkcalculus.dnc.bounds.disco.BoundingCurves_Disco_ConPwAffine;
 import org.networkcalculus.dnc.bounds.disco.Bounds_Disco_PwAffine;
 import org.networkcalculus.dnc.curves.CurveUtils;
-import org.networkcalculus.dnc.curves.Curve_PwAffine;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.curves.LinearSegment;
 import org.networkcalculus.dnc.curves.disco.pw_affine.CurveUtils_Disco_PwAffine;
 import org.networkcalculus.dnc.curves.mpa_rtc.LinearSegment_MPARTC;
@@ -68,7 +68,7 @@ public enum AlgDncBackend_MPARTC_DISCO_ConPwAffine implements AlgDncBackend {
 	}
 
 	@Override
-	public Curve_PwAffine getCurveFactory() {
+	public CurveFactory_Affine getCurveFactory() {
 		return Curve_MPARTC_PwAffine.getFactory();
 	}
 

--- a/java/org/networkcalculus/dnc/AlgDncBackend_MPARTC_DISCO_ConPwAffine.java
+++ b/java/org/networkcalculus/dnc/AlgDncBackend_MPARTC_DISCO_ConPwAffine.java
@@ -34,8 +34,10 @@ import org.networkcalculus.dnc.bounds.BoundingCurves;
 import org.networkcalculus.dnc.bounds.Bounds;
 import org.networkcalculus.dnc.bounds.disco.BoundingCurves_Disco_ConPwAffine;
 import org.networkcalculus.dnc.bounds.disco.Bounds_Disco_PwAffine;
+import org.networkcalculus.dnc.curves.CurveUtils;
 import org.networkcalculus.dnc.curves.Curve_PwAffine;
 import org.networkcalculus.dnc.curves.LinearSegment;
+import org.networkcalculus.dnc.curves.disco.pw_affine.CurveUtils_Disco_PwAffine;
 import org.networkcalculus.dnc.curves.mpa_rtc.LinearSegment_MPARTC;
 import org.networkcalculus.dnc.curves.mpa_rtc.pw_affine.Curve_MPARTC_PwAffine;
 
@@ -68,6 +70,11 @@ public enum AlgDncBackend_MPARTC_DISCO_ConPwAffine implements AlgDncBackend {
 	@Override
 	public Curve_PwAffine getCurveFactory() {
 		return Curve_MPARTC_PwAffine.getFactory();
+	}
+
+	@Override
+	public CurveUtils getCurveUtils() {
+		return CurveUtils_Disco_PwAffine.getInstance();
 	}
 
 	@Override 

--- a/java/org/networkcalculus/dnc/AlgDncBackend_MPARTC_PwAffine.java
+++ b/java/org/networkcalculus/dnc/AlgDncBackend_MPARTC_PwAffine.java
@@ -33,8 +33,10 @@ import org.networkcalculus.dnc.bounds.BoundingCurves;
 import org.networkcalculus.dnc.bounds.Bounds;
 import org.networkcalculus.dnc.bounds.disco.BoundingCurves_Disco_ConPwAffine;
 import org.networkcalculus.dnc.bounds.mpa_rtc.Bounds_MPARTC_PwAffine;
+import org.networkcalculus.dnc.curves.CurveUtils;
 import org.networkcalculus.dnc.curves.Curve_PwAffine;
 import org.networkcalculus.dnc.curves.LinearSegment;
+import org.networkcalculus.dnc.curves.disco.pw_affine.CurveUtils_Disco_PwAffine;
 import org.networkcalculus.dnc.curves.mpa_rtc.LinearSegment_MPARTC;
 import org.networkcalculus.dnc.curves.mpa_rtc.pw_affine.Curve_MPARTC_PwAffine;
 
@@ -63,6 +65,11 @@ public enum AlgDncBackend_MPARTC_PwAffine implements AlgDncBackend {
 	@Override
 	public Curve_PwAffine getCurveFactory() {
 		return Curve_MPARTC_PwAffine.getFactory();
+	}
+
+	@Override
+	public CurveUtils getCurveUtils() {
+		return CurveUtils_Disco_PwAffine.getInstance();
 	}
 
 	@Override 

--- a/java/org/networkcalculus/dnc/AlgDncBackend_MPARTC_PwAffine.java
+++ b/java/org/networkcalculus/dnc/AlgDncBackend_MPARTC_PwAffine.java
@@ -33,8 +33,8 @@ import org.networkcalculus.dnc.bounds.BoundingCurves;
 import org.networkcalculus.dnc.bounds.Bounds;
 import org.networkcalculus.dnc.bounds.disco.BoundingCurves_Disco_ConPwAffine;
 import org.networkcalculus.dnc.bounds.mpa_rtc.Bounds_MPARTC_PwAffine;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.curves.CurveUtils;
-import org.networkcalculus.dnc.curves.Curve_PwAffine;
 import org.networkcalculus.dnc.curves.LinearSegment;
 import org.networkcalculus.dnc.curves.disco.pw_affine.CurveUtils_Disco_PwAffine;
 import org.networkcalculus.dnc.curves.mpa_rtc.LinearSegment_MPARTC;
@@ -63,7 +63,7 @@ public enum AlgDncBackend_MPARTC_PwAffine implements AlgDncBackend {
 	}
 
 	@Override
-	public Curve_PwAffine getCurveFactory() {
+	public CurveFactory_Affine getCurveFactory() {
 		return Curve_MPARTC_PwAffine.getFactory();
 	}
 
@@ -87,4 +87,9 @@ public enum AlgDncBackend_MPARTC_PwAffine implements AlgDncBackend {
 	public LinearSegment.Builder getLinearSegmentFactory() {
 		return LinearSegment_MPARTC.getBuilder();
 	}
+
+    @Override
+    public String toString() {
+        return assembleString(this.name(), MinPlus_MPARTC_PwAffine.MINPLUS_MPARTC.name());
+    }
 }

--- a/java/org/networkcalculus/dnc/bounds/mpa_rtc/Bounds_MPARTC_PwAffine.java
+++ b/java/org/networkcalculus/dnc/bounds/mpa_rtc/Bounds_MPARTC_PwAffine.java
@@ -56,7 +56,7 @@ public enum Bounds_MPARTC_PwAffine implements Bounds {
 
     /**
      * MPA RTC does not have an implementation for finding the x-coordinate of
-     * two curves' first intersection. We have to use the DISCO implementation,
+     * two curves' first intersection. We have to use the implementation by DISCO,
      * relying on the curve interface compliance of the MPA RTC curve wrapper.
      * 
      * TODO: This restricts the entire class to non-periodic curves,

--- a/java/org/networkcalculus/dnc/bounds/mpa_rtc/Bounds_MPARTC_PwAffine.java
+++ b/java/org/networkcalculus/dnc/bounds/mpa_rtc/Bounds_MPARTC_PwAffine.java
@@ -63,7 +63,7 @@ public enum Bounds_MPARTC_PwAffine implements Bounds {
      *       a restriction inherited from the DISCO implementation. 
      */
     public Num delayARB(ArrivalCurve arrival_curve, ServiceCurve service_curve) {
-    	return Curve.getXIntersection(arrival_curve,service_curve);
+    	return Curve.getUtils().getXIntersection(arrival_curve,service_curve);
     }
 
     public Num delayFIFO(ArrivalCurve arrival_curve, ServiceCurve service_curve) {

--- a/java/org/networkcalculus/dnc/curves/mpa_rtc/MPARTC_Curve_Wrapper.java
+++ b/java/org/networkcalculus/dnc/curves/mpa_rtc/MPARTC_Curve_Wrapper.java
@@ -1,0 +1,11 @@
+package org.networkcalculus.dnc.curves.mpa_rtc;
+
+import ch.ethz.rtc.kernel.Curve;
+
+public abstract class MPARTC_Curve_Wrapper {
+	protected Curve rtc_curve;
+
+	public Curve getRtc_curve() {
+		return rtc_curve;
+	}
+}

--- a/java/org/networkcalculus/dnc/curves/mpa_rtc/pw_affine/Curve_MPARTC_PwAffine.java
+++ b/java/org/networkcalculus/dnc/curves/mpa_rtc/pw_affine/Curve_MPARTC_PwAffine.java
@@ -91,8 +91,8 @@ public class Curve_MPARTC_PwAffine implements Curve_PwAffine {
 	// --------------------------------------------------------------------------------------------------------------
 
 	// Attention
-	// * Default behavior of the DiscoDNC cannot be reenacted with the RTC.
-	// * DiscoDNC initializes curves with overlapping (x,y,r)=(0,0,0) segments.
+	// * Default behavior of the DNC cannot be reenacted with the RTC.
+	// * DNC initializes curves with overlapping (x,y,r)=(0,0,0) segments.
 	// That causes an error with the RTC implementation.
 	// We initialize with (segment_number,segment_number,0) instead.
 	private void createZeroSegmentsCurve(int segment_count) {
@@ -702,7 +702,7 @@ public class Curve_MPARTC_PwAffine implements Curve_PwAffine {
 	// --------------------------------------------------------------------------------------------------------------
 
 	// ------------------------------------------------------------
-	// DiscoDNC compliance
+	// DNC compliance
 	// ------------------------------------------------------------
 	public Curve_MPARTC_PwAffine createCurve(List<LinearSegment> segments) {
 		Curve_MPARTC_PwAffine msc_rtc = new Curve_MPARTC_PwAffine();
@@ -743,7 +743,7 @@ public class Curve_MPARTC_PwAffine implements Curve_PwAffine {
 	// --------------------------------------------------------------------------------------------------------------
 
 	// ------------------------------------------------------------
-	// DiscoDNC compliance
+	// DNC compliance
 	// ------------------------------------------------------------
 	public ServiceCurve_MPARTC_PwAffine createServiceCurve() {
 		return new ServiceCurve_MPARTC_PwAffine();
@@ -801,7 +801,7 @@ public class Curve_MPARTC_PwAffine implements Curve_PwAffine {
 	// --------------------------------------------------------------------------------------------------------------
 
 	// ------------------------------------------------------------
-	// DiscoDNC compliance
+	// DNC compliance
 	// ------------------------------------------------------------
 	public ArrivalCurve_MPARTC_PwAffine createArrivalCurve() {
 		return new ArrivalCurve_MPARTC_PwAffine();
@@ -858,7 +858,7 @@ public class Curve_MPARTC_PwAffine implements Curve_PwAffine {
 	// --------------------------------------------------------------------------------------------------------------
 
 	// ------------------------------------------------------------
-	// DiscoDNC compliance
+	// DNC compliance
 	// ------------------------------------------------------------
 	public MaxServiceCurve_MPARTC_PwAffine createMaxServiceCurve() {
 		return new MaxServiceCurve_MPARTC_PwAffine();

--- a/java/org/networkcalculus/dnc/curves/mpa_rtc/pw_affine/Curve_MPARTC_PwAffine.java
+++ b/java/org/networkcalculus/dnc/curves/mpa_rtc/pw_affine/Curve_MPARTC_PwAffine.java
@@ -820,7 +820,7 @@ public class Curve_MPARTC_PwAffine implements Curve_PwAffine {
 	}
 
 	public ArrivalCurve_MPARTC_PwAffine createArrivalCurve(org.networkcalculus.dnc.curves.Curve curve, boolean remove_latency) {
-		return createArrivalCurve(org.networkcalculus.dnc.curves.Curve.removeLatency(curve));
+		return createArrivalCurve(org.networkcalculus.dnc.curves.Curve.getUtils().removeLatency(curve));
 	}
 
 	public ArrivalCurve_MPARTC_PwAffine createZeroArrivals() {

--- a/java/org/networkcalculus/dnc/curves/mpa_rtc/pw_affine/Curve_MPARTC_PwAffine.java
+++ b/java/org/networkcalculus/dnc/curves/mpa_rtc/pw_affine/Curve_MPARTC_PwAffine.java
@@ -30,6 +30,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.networkcalculus.dnc.Calculator;
+import org.networkcalculus.dnc.curves.CurveFactory_Affine;
 import org.networkcalculus.dnc.curves.Curve_Affine;
 import org.networkcalculus.dnc.curves.Curve_PwAffine;
 import org.networkcalculus.dnc.curves.LinearSegment;
@@ -42,7 +43,7 @@ import ch.ethz.rtc.kernel.Curve;
 import ch.ethz.rtc.kernel.Segment;
 import ch.ethz.rtc.kernel.SegmentList;
 
-public class Curve_MPARTC_PwAffine extends MPARTC_Curve_Wrapper implements Curve_PwAffine {
+public class Curve_MPARTC_PwAffine extends MPARTC_Curve_Wrapper implements Curve_PwAffine, CurveFactory_Affine {
 	private static Curve_MPARTC_PwAffine instance = new Curve_MPARTC_PwAffine();
 
 	protected boolean is_delayed_infinite_burst = false;

--- a/java/org/networkcalculus/dnc/curves/mpa_rtc/pw_affine/Curve_MPARTC_PwAffine.java
+++ b/java/org/networkcalculus/dnc/curves/mpa_rtc/pw_affine/Curve_MPARTC_PwAffine.java
@@ -35,16 +35,15 @@ import org.networkcalculus.dnc.curves.Curve_PwAffine;
 import org.networkcalculus.dnc.curves.LinearSegment;
 import org.networkcalculus.dnc.curves.mpa_rtc.Curves_MPARTC_Configuration;
 import org.networkcalculus.dnc.curves.mpa_rtc.LinearSegment_MPARTC;
+import org.networkcalculus.dnc.curves.mpa_rtc.MPARTC_Curve_Wrapper;
 import org.networkcalculus.num.Num;
 
 import ch.ethz.rtc.kernel.Curve;
 import ch.ethz.rtc.kernel.Segment;
 import ch.ethz.rtc.kernel.SegmentList;
 
-public class Curve_MPARTC_PwAffine implements Curve_PwAffine {
+public class Curve_MPARTC_PwAffine extends MPARTC_Curve_Wrapper implements Curve_PwAffine {
 	private static Curve_MPARTC_PwAffine instance = new Curve_MPARTC_PwAffine();
-
-	protected ch.ethz.rtc.kernel.Curve rtc_curve;
 
 	protected boolean is_delayed_infinite_burst = false;
 	protected boolean is_rate_latency = false;
@@ -101,10 +100,6 @@ public class Curve_MPARTC_PwAffine implements Curve_PwAffine {
 			segList_rtc.add(new Segment((double) i, (double) i, 0));
 		}
 		rtc_curve = new Curve(segList_rtc);
-	}
-
-	public Curve getRtc_curve() {
-		return rtc_curve;
 	}
 
 	// Accepts string representations of RTC as well as

--- a/java/org/networkcalculus/dnc/curves/mpa_rtc/pw_affine/ServiceCurve_MPARTC_PwAffine.java
+++ b/java/org/networkcalculus/dnc/curves/mpa_rtc/pw_affine/ServiceCurve_MPARTC_PwAffine.java
@@ -30,7 +30,6 @@ import org.networkcalculus.dnc.curves.mpa_rtc.pw_affine.Curve_MPARTC_PwAffine;
 import org.networkcalculus.dnc.curves.mpa_rtc.pw_affine.ServiceCurve_MPARTC_PwAffine;
 
 import ch.ethz.rtc.kernel.Curve;
-import ch.ethz.rtc.kernel.SegmentList;
 
 public class ServiceCurve_MPARTC_PwAffine extends Curve_MPARTC_PwAffine implements ServiceCurve {
     // --------------------------------------------------------------------------------------------------------------
@@ -48,38 +47,12 @@ public class ServiceCurve_MPARTC_PwAffine extends Curve_MPARTC_PwAffine implemen
         copy(curve);
     }
 
-    public ServiceCurve_MPARTC_PwAffine(ch.ethz.rtc.kernel.Curve curve) {
+    public ServiceCurve_MPARTC_PwAffine(Curve curve) {
         rtc_curve = curve.clone();
     }
 
     public ServiceCurve_MPARTC_PwAffine(String service_curve_str) throws Exception {
         super.initializeCurve(service_curve_str);
-    }
-
-    public ServiceCurve_MPARTC_PwAffine(SegmentList aperSegments) {
-        rtc_curve = new Curve(aperSegments);
-    }
-
-    public ServiceCurve_MPARTC_PwAffine(SegmentList perSegments, double py0, long period, double pdy) {
-        rtc_curve = new Curve(perSegments, py0, period, pdy);
-    }
-
-    public ServiceCurve_MPARTC_PwAffine(SegmentList perSegments, double py0, long period, double pdy, String name) {
-        rtc_curve = new Curve(perSegments, py0, period, pdy, name);
-    }
-
-    public ServiceCurve_MPARTC_PwAffine(SegmentList aperSegments, SegmentList perSegments, double px0, double py0,
-                                        long period, double pdy) {
-        rtc_curve = new Curve(aperSegments, perSegments, px0, py0, period, pdy);
-    }
-
-    public ServiceCurve_MPARTC_PwAffine(SegmentList aperSegments, SegmentList perSegments, double px0, double py0,
-                                        long period, double pdy, String name) {
-        rtc_curve = new Curve(aperSegments, perSegments, px0, py0, period, pdy, name);
-    }
-
-    public ServiceCurve_MPARTC_PwAffine(SegmentList aperSegments, String name) {
-        rtc_curve = new Curve(aperSegments, name);
     }
 
     // --------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
See PR NetCal/DNC#93

The additions make changes needed to break the assumption that all curve backends will work with the same static util methods -- or, put differently, that all curve backends will implement the DNC interface. Ultimately, this is a step towards wrapping the RTC MPA toolbox and using it as a backend for our analyses without duplicating curve util code (see NetCal/DNCext_MPARTC#14 and NetCal/DNC#86).